### PR TITLE
Ret 6280 - Playwright Test

### DIFF
--- a/playwrighte2e/pages/claimantCitizenHub/et1ClaimsListPage.ts
+++ b/playwrighte2e/pages/claimantCitizenHub/et1ClaimsListPage.ts
@@ -68,4 +68,10 @@ export class Et1ClaimsListPage extends BasePage {
     await caseNumberLink.click();
     return text? text: '';
   }
+
+  async viewYourET1Claims() {
+    await expect(this.page.getByRole('heading', { name: 'Your claim has been saved' })).toBeVisible();
+    await this.page.getByRole('button', { name: 'View your ET1 claims' }).click();
+    await expect(this.page.getByRole('heading', { name: 'ET1 claims' })).toBeVisible();
+  }
 }

--- a/playwrighte2e/pages/helpers/CuiCaseCreationHelper.ts
+++ b/playwrighte2e/pages/helpers/CuiCaseCreationHelper.ts
@@ -134,3 +134,20 @@ export async function vetAndAcceptCitizenCase(
 
   return caseNumber;
 }
+
+export async function partiallyCreateCaseViaCitizenUI(
+  page: Page,
+  citizenPreLoginPage: CUIPreLoginPage,
+  citizenPostLoginPage: CUIPostLoginPages,
+  personalDetailsPage: PersonalDetailsPage,
+  region: string,
+  loginMethod: () => Promise<void>,
+) {
+  await page.goto(config.etSyaUiUrl);
+  await citizenPreLoginPage.processPreLoginPagesForTheDraftApplication(region);
+  await loginMethod();
+  await citizenPostLoginPage.processPostLoginPagesForTheDraftApplication();
+  const location = region === 'EnglandWales' ? 'England' : region;
+  await personalDetailsPage.processPersonalDetails(userDetailsData.postcode, location, userDetailsData.addressOption);
+  await page.getByRole('button', { name: 'Save as draft' }).click();
+}

--- a/playwrighte2e/tests/caseSubmission.test.ts
+++ b/playwrighte2e/tests/caseSubmission.test.ts
@@ -1,6 +1,6 @@
 import { test } from '../fixtures/common.fixture';
 import userDetailsData from '../resources/payload/user-details.json';
-import { createCaseViaCitizenUI, vetAndAcceptCitizenCase } from '../pages/helpers/CuiCaseCreationHelper.ts';
+import { createCaseViaCitizenUI, vetAndAcceptCitizenCase, partiallyCreateCaseViaCitizenUI } from '../pages/helpers/CuiCaseCreationHelper.ts';
 import { CaseTypeLocation, Events } from '../config/case-data.ts';
 import { config, users } from '../config/config.dynamic.ts';
 
@@ -231,4 +231,23 @@ test.describe('Case creation in Citizen UI', () => {
       users.etManageCaseUser
     );
   });
+
+  test('Partially create a claim and return to viewing your et1 claims', async ({
+ page,
+    loginPage,
+    citizenPreLoginPage,
+    citizenPostLoginPage,
+    personalDetailsPage,
+    et1ClaimsListPage,
+  }) => {
+    await partiallyCreateCaseViaCitizenUI(
+      page,
+      citizenPreLoginPage,
+      citizenPostLoginPage,
+      personalDetailsPage,
+      'EnglandWales',
+      async() => { await loginPage.processLogin(users.etClaimant, config.etSyaUiUrl) }
+        )
+    await et1ClaimsListPage.viewYourET1Claims()
+    });
 });


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [RET-6280](https://tools.hmcts.net/jira/browse/RET-6280)

### Change description

<!--

-->
Created a new playwright test for "Investigate and implement navigation back to Case List (SYA)" The user should be able to return to the view my ET1 cases page from:
After saving a draft claim (your-claim-has-been-saved)
When viewing a specific claim (citizen-hub)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
