### PR TITLE
Use a single click for submit actions

### DIFF
--- a/playwrighte2e/pages/basePage.ts
+++ b/playwrighte2e/pages/basePage.ts
@@ -127,7 +127,7 @@ export abstract class BasePage {
     let attempt = 0;
 
     while (attempt < maxRetries) {
-      await this.submitButton.click({clickCount:2, force: true });
+      await this.submitButton.click({force: true });
       await this.page.waitForLoadState('load', { timeout: 4000 });
       await this.waitForSpinner(180_000);
       if (!submitted) return;


### PR DESCRIPTION
### Change description

Use a single click when submitting Playwright events.

The shared submit helper currently forces a double click. This sends two concurrent requests for non-idempotent submission actions, causing a successful update to race with a 409 CaseConcurrencyException and redirect to `/not-found`.

This restores the browser behaviour expected by the test while retaining the existing retry and wait handling.

### Security Vulnerability Assessment

**CVE Suppression:** No