### PR TITLE
Fix jurisdiction tab assertion

### DIFF
--- a/playwrighte2e/tests/etEvents.test.ts
+++ b/playwrighte2e/tests/etEvents.test.ts
@@ -35,7 +35,7 @@ test.describe('Various events in mange case application', () => {
       {
         tabName: 'Jurisdictions',
         tabContent:[
-          'Jurisdictions',
+          'Jurisdiction',
           'DDA'
         ]
       }


### PR DESCRIPTION
### Change description

Correct the jurisdiction event test to assert the singular `Jurisdiction` field label rendered inside the active tab content.

